### PR TITLE
update readme typo and app template

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ oauthConfig:
     provider:
       apiVersion: v1
       kind: RequestHeaderIdentityProvider
-      loginURL: "https://sp.example.org/mod_auth_mellon?${query}"
+      loginURL: "https://sp.example.org/mod_auth_mellon/?${query}"
       clientCA: /etc/origin/master/ca.crt
       headers:
       - Remote-User

--- a/saml-auth.template
+++ b/saml-auth.template
@@ -87,10 +87,6 @@
                                         "value": "${OSE_API_PUBLIC_URL}"
                                     },
                                     {
-                                        "name": "REMOTE_USER_SAML_ATTRIBUTE",
-                                        "value": "${REMOTE_USER_SAML_ATTRIBUTE}"
-                                    },
-                                    {
                                         "name": "LOG_LEVEL",
                                         "value": "${LOG_LEVEL}"
                                     }
@@ -148,11 +144,6 @@
             "name": "OSE_API_PUBLIC_URL",
             "description": "The OpenShift Enterprise API public URL"
         },
-#        {
-#            "name": "REMOTE_USER_SAML_ATTRIBUTE",
-#            "description": "SAML attribute mapping",
-#            "value": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
-#        },
         {
             "name": "LOG_LEVEL",
             "description": "Logging level for mod_auth_mellon",


### PR DESCRIPTION
1. update readme typo
2. update saml-auth template. If leave "REMOTE_USER_SAML_ATTRIBUTE" be there, when login, use will encounter Forbidden error - "You don't have permission to access /mod_auth_mellon/ on this server.".
