### PR TITLE
make default image become a template var

### DIFF
--- a/saml-auth.template
+++ b/saml-auth.template
@@ -98,16 +98,7 @@
                                     {
                                         "containerPort": 8443
                                     }
-                                ],
-                                "readinessProbe": {
-                                    "httpGet": {
-                                        "path": "/logged_out.html",
-                                        "port": 8443,
-                                        "scheme": "HTTPS"
-                                    },
-                                    "initialDelaySeconds": 10,
-                                    "timeoutSeconds": 1
-                                }
+                                ]
                             }
                         ]
                     }

--- a/saml-auth.template
+++ b/saml-auth.template
@@ -92,7 +92,7 @@
                                     }
 
                                 ],
-                                "image": "openshift3/saml-service-provider",
+                                "image": "${APPLICATION_IMAGE}",
                                 "name": "saml-auth",
                                 "ports": [
                                     {
@@ -143,6 +143,11 @@
         {
             "name": "OSE_API_PUBLIC_URL",
             "description": "The OpenShift Enterprise API public URL"
+        },
+        {
+            "name": "APPLICATION_IMAGE",
+            "description": "The image that used to deploy the SAML app"
+            "value": "openshift3/saml-service-provider"
         },
         {
             "name": "LOG_LEVEL",


### PR DESCRIPTION
When trying to deploy the saml app on AWS/GCE, due to https://bugzilla.redhat.com/show_bug.cgi?id=1316341#c6, QE have to specify saml image using registry.qe.openshift.com/openshift3/saml-service-provider instead of openshift3/saml-service-provider. This PR would make saml app deployment more flexible.

@brenton could you help have a review.
