### PR TITLE
remove stale health check

### DIFF
--- a/saml-auth.template
+++ b/saml-auth.template
@@ -98,16 +98,7 @@
                                     {
                                         "containerPort": 8443
                                     }
-                                ],
-                                "readinessProbe": {
-                                    "httpGet": {
-                                        "path": "/logged_out.html",
-                                        "port": 8443,
-                                        "scheme": "HTTPS"
-                                    },
-                                    "initialDelaySeconds": 10,
-                                    "timeoutSeconds": 1
-                                }
+                                ]
                             }
                         ]
                     }


### PR DESCRIPTION
For 3.2, when deploying saml-auth pod, get the following warning, but pod could become "running" status.
# oc describe po saml-auth-1-dx3qo

...
  57m       57m     3   {kubelet xxx.example.com}   spec.containers{saml-auth}  Warning     Unhealthy   Readiness probe failed: Get https://10.1.0.6:8443/logged_out.html: dial tcp 10.1.0.6:8443: connection refused

While for 3.3, the failed health check make the pod ended with "error".
# oc get po

NAME                      READY     STATUS    RESTARTS   AGE
saml-auth-2-d70n7         0/1       Running   0          4m
saml-auth-2-deploy        1/1       Running   0          5m
# oc describe po saml-auth-2-d70n7

  5s        5s      1   {kubelet xxx.example.com}   spec.containers{saml-auth}  Warning     Unhealthy   Readiness probe failed: Get https://10.1.1.3:8443/logged_out.html: local error: no renegotiation
# oc get po

NAME                      READY     STATUS    RESTARTS   AGE
saml-auth-2-deploy        0/1       Error     0          13m

Seem like the health check is stale, so suggest remove it, or correct it.
