### PR TITLE
Bug 1366528 - saml-auth pod error because of readiness probe failure …

### DIFF
--- a/saml-auth.template
+++ b/saml-auth.template
@@ -100,10 +100,8 @@
                                     }
                                 ],
                                 "readinessProbe": {
-                                    "httpGet": {
-                                        "path": "/logged_out.html",
-                                        "port": 8443,
-                                        "scheme": "HTTPS"
+                                    "exec": {
+                                       "command": [ "/usr/bin/curl", "-k", "https://127.0.0.1:8443/logged_out.html" ]
                                     },
                                     "initialDelaySeconds": 10,
                                     "timeoutSeconds": 1


### PR DESCRIPTION
…for 3.3

Golang 1.6 changed it's preferred tls cipher yet does not support
renegotiation.  I tried several different secure cipher settings in apache yet
each triggered a renegotiation.  This is a workaround that basically does the
same this only using curl in the pod itself.
