### PR TITLE
Make auth proxy match master oauth paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ oc rollout latest saml-auth
 ```
 
 ### Deploying the image
-Add saml-auth template to OSE - (required parameters: APPLICATION_DOMAIN, OSE_API_PUBLIC_URL)
+Add saml-auth template to OSE - (required parameters: APPLICATION_DOMAIN, PROXY_PATH, PROXY_DESTINATION)
 ```sh
 oc create -f ./saml-auth.template -n openshift
 ```
@@ -101,7 +101,7 @@ oc create -f ./saml-auth.template -n openshift
 Create a new application (test with '-o json', remove when satisfied with the result)
 ```sh
 oc new-app saml-auth \
-    -p APPLICATION_DOMAIN=sp.example.org -p OSE_API_PUBLIC_URL=https://ose.example.com:8443/oauth/authorize -o json
+    -p APPLICATION_DOMAIN=sp.example.org -p PROXY_PATH=/oauth/ -p PROXY_DESTINATION=https://ose.example.com:8443/oauth/ -o json
 ```
 
 
@@ -160,7 +160,7 @@ oauthConfig:
     provider:
       apiVersion: v1
       kind: RequestHeaderIdentityProvider
-      loginURL: "https://sp.example.org/mod_auth_mellon/?${query}"
+      loginURL: "https://sp.example.org/oauth/authorize?${query}"
       clientCA: /etc/origin/master/ca.crt
       headers:
       - Remote-User

--- a/openshift.conf
+++ b/openshift.conf
@@ -51,12 +51,12 @@ LogLevel ${LOG_LEVEL}
 
 </Location>
 
-<Location /mod_auth_mellon/>
+<Location ${PROXY_PATH}>
     # Protect with auth
     MellonEnable "auth"
 
     # Proxy to backend once authenticated
-    ProxyPass ${OSE_API_PUBLIC_URL}
+    ProxyPass ${PROXY_DESTINATION}
 
     <If "-z env('REMOTE_USER_SAML_ATTRIBUTE')">
        # Set the Remote-User header to the value of the authenticated username

--- a/saml-auth.template
+++ b/saml-auth.template
@@ -83,8 +83,12 @@
                                         "value": "${APPLICATION_DOMAIN}"
                                     },
                                     {
-                                        "name": "OSE_API_PUBLIC_URL",
-                                        "value": "${OSE_API_PUBLIC_URL}"
+                                        "name": "PROXY_PATH",
+                                        "value": "${PROXY_PATH}"
+                                    },
+                                    {
+                                        "name": "PROXY_DESTINATION",
+                                        "value": "${PROXY_DESTINATION}"
                                     },
                                     {
                                         "name": "LOG_LEVEL",
@@ -139,8 +143,14 @@
             "description": "The exposed hostname that will route to the SAML service, if left blank a value will be defaulted."
         },
         {
-            "name": "OSE_API_PUBLIC_URL",
-            "description": "The OpenShift Enterprise API public URL"
+            "name": "PROXY_PATH",
+            "description": "The root path that will proxy to the OpenShift Enterprise OAuth server, with a trailing slash (e.g. /oauth/)",
+            "required": true
+        },
+        {
+            "name": "PROXY_DESTINATION",
+            "description": "The full URL, including port and path, with a trailing slash, that the PROXY_PATH should proxy (e.g. https://api.example.com:8443/oauth/)",
+            "required": true
         },
         {
             "name": "LOG_LEVEL",


### PR DESCRIPTION
This makes the auth proxy work for multiple oauth subpaths, including the /oauth/approve subpath.

See https://bugzilla.redhat.com/show_bug.cgi?id=1421629